### PR TITLE
Solve issue #56 : AndroidTest UnauthorizedAppTest: Fails due to PiracyCheckerError enum return value not PIRATE_APP_INSTALLED but BLOCK_PIRATE_APP.

### DIFF
--- a/app/src/androidTest/java/com/github/javiersantos/piracychecker/UnauthorizedAppTest.java
+++ b/app/src/androidTest/java/com/github/javiersantos/piracychecker/UnauthorizedAppTest.java
@@ -74,7 +74,8 @@ public class UnauthorizedAppTest {
 
                             @Override
                             public void dontAllow(@NonNull PiracyCheckerError error, @Nullable PirateApp app) {
-                                if (error == PiracyCheckerError.PIRATE_APP_INSTALLED)
+                                if (error == PiracyCheckerError.PIRATE_APP_INSTALLED
+                                   || error == PiracyCheckerError.BLOCK_PIRATE_APP)
                                     assertTrue("PiracyChecker OK", true);
                                 else
                                     assertTrue("PiracyChecker FAILED : PiracyCheckError is not " + error.toString(), false);
@@ -106,7 +107,8 @@ public class UnauthorizedAppTest {
 
                             @Override
                             public void dontAllow(@NonNull PiracyCheckerError error, @Nullable PirateApp app) {
-                                if (error == PiracyCheckerError.PIRATE_APP_INSTALLED)
+                                if (error == PiracyCheckerError.PIRATE_APP_INSTALLED
+                                   || error == PiracyCheckerError.BLOCK_PIRATE_APP)
                                     assertTrue("PiracyChecker OK", true);
                                 else
                                     assertTrue("PiracyChecker FAILED : PiracyCheckError is not " + error.toString(), false);


### PR DESCRIPTION
Solves : AndroidTest UnauthorizedAppTest: Fails due to PiracyCheckerError enum return value not PIRATE_APP_INSTALLED but BLOCK_PIRATE_APP.