### PR TITLE
Update readme.md to add more clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Some of the techniques included in this library can be found [here](https://www.
 Add the repository to your project **build.gradle**:
 
 ```gradle
-repositories {
-    maven {
-        url "https://jitpack.io"
+allprojects {
+    repositories {
+        maven {
+            url "https://jitpack.io"
+        }
     }
 }
 ```


### PR DESCRIPTION
Sometimes developers place the `repositories {...}` block inside of `buildscript` instead of `allprojects`, so I added `allprojects` to prevent them making this mistake.