### PR TITLE
Get installer package name in API 30+

### DIFF
--- a/library/src/main/java/com/github/javiersantos/piracychecker/utils/LibraryUtils.kt
+++ b/library/src/main/java/com/github/javiersantos/piracychecker/utils/LibraryUtils.kt
@@ -92,7 +92,11 @@ internal fun Context.verifySigningCertificates(appSignatures: Array<String>): Bo
 
 internal fun Context.verifyInstallerId(installerID: List<InstallerID>): Boolean {
     val validInstallers = ArrayList<String>()
-    val installer = packageManager.getInstallerPackageName(packageName)
+    val installer = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        packageManager.getInstallSourceInfo(packageName).installingPackageName
+    } else {
+        packageManager.getInstallerPackageName(packageName)
+    }
     for (id in installerID) {
         validInstallers.addAll(id.toIDs())
     }


### PR DESCRIPTION
[getInstallerPackageName](https://developer.android.com/reference/android/content/pm/PackageManager#getInstallerPackageName(java.lang.String)) was deprecated in API level 30 so we need use another method to get installer package name.